### PR TITLE
Removed usages of Array.forEach, Array.map & Array.indexOf

### DIFF
--- a/computed.js
+++ b/computed.js
@@ -3,17 +3,21 @@ var Observable = require("./index.js")
 module.exports = computed
 
 function computed(observables, lambda) {
-    var values = observables.map(function (o) {
-        return o()
-    })
-    var result = Observable(lambda.apply(null, values))
+    var values = []
 
-    observables.forEach(function (o, index) {
-        o(function (newValue) {
-            values[index] = newValue
+    function listener(i) {
+        return function (value) {
+            values[i] = value
             result.set(lambda.apply(null, values))
-        })
-    })
+        };
+    }
+
+    for (var i = 0, len = observables.length; i < len; i++) {
+        values.push(observables[i]())
+        observables[i](listener(i))
+    }
+
+    var result = Observable(lambda.apply(null, values))
 
     return result
 }

--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ function Observable(value) {
 
     observable.set = function (v) {
         value = v
-        listeners.forEach(function (f) {
-            f(v)
-        })
+
+        for (var i = 0, len = listeners.length; i < len; i++) {
+            listeners[i](v)
+        }
     }
 
     return observable
@@ -21,7 +22,12 @@ function Observable(value) {
         listeners.push(listener)
 
         return function remove() {
-            listeners.splice(listeners.indexOf(listener), 1)
+            for (var i = 0, len = listeners.length; i < len; i++) {
+                if (listeners[i] === listener) {
+                    listeners.splice(i, 1)
+                    break
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
 This makes the module ES3 compliant, opening up its use in IE<9 (and other unsavoury browsers).

Here's a JSPerf of the changes, which result a great speedup in ES5 environments too: http://jsperf.com/observable-es5-vs-es3
