### PR TITLE
Simplify remove to use [].push return instead of loop to find

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,15 +19,10 @@ function Observable(value) {
             return value
         }
 
-        listeners.push(listener)
+        var index = listeners.push(listener) - 1
 
         return function remove() {
-            for (var i = 0, len = listeners.length; i < len; i++) {
-                if (listeners[i] === listener) {
-                    listeners.splice(i, 1)
-                    break
-                }
-            }
+            listeners.splice(index, 1)
         }
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,31 @@ test("observable change", function (assert) {
     assert.end()
 })
 
+test("remove listener", function (assert) {
+    var v = Observable("init value")
+    var values = []
+
+    var l1 = v(function onchange(newValue) {
+        values.push("l1: " + newValue)
+    })
+
+    var l2 = v(function onchange(newValue) {
+        values.push("l2: " + newValue)
+    })
+
+    var l3 = v(function onchange(newValue) {
+        values.push("l3: " + newValue)
+    })
+
+    l2()
+
+    v.set("new value")
+
+    assert.deepEqual(values, ["l1: new value", "l3: new value"])
+
+    assert.end()
+})
+
 test("computed observable", function (assert) {
     var v1 = Observable("one")
     var v2 = Observable("two")


### PR DESCRIPTION
Since `[].push` returns the new array length, we can get the index of the listener by subtracting 1 and `[].splice` there.